### PR TITLE
#15607.py

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
@@ -191,16 +191,19 @@ MSSQL_GET_STORED_PROCEDURES = textwrap.dedent(
     """
 SELECT
   ROUTINE_NAME AS name,
-  NULL AS owner,
+  NULL AS owner,            
   ROUTINE_BODY AS language,
-  ROUTINE_DEFINITION AS definition
-FROM INFORMATION_SCHEMA.ROUTINES
+  l.definition AS definition
+FROM INFORMATION_SCHEMA.ROUTINES r
+JOIN sys.procedures p ON p.name = r.ROUTINE_NAME 
+JOIN sys.sql_modules l on l.object_id = p.object_id
  WHERE ROUTINE_TYPE = 'PROCEDURE'
    AND ROUTINE_CATALOG = '{database_name}'
    AND ROUTINE_SCHEMA = '{schema_name}' 
    AND LEFT(ROUTINE_NAME, 3) NOT IN ('sp_', 'xp_', 'ms_')
     """
 )
+
 
 MSSQL_GET_STORED_PROCEDURE_QUERIES = textwrap.dedent(
     """


### PR DESCRIPTION
Short blurb explaining:
- What changes did you make?
 I rewrote the query that gets stored procedures from ms sql and its definitions.
- Why did you make them?
Because i found out that openmetadata 1.3.0 cant get more than 4000 symbols of stored procedure definition
- How did you test your changes?
I have replaced one file in our docker image and ran ingestion. There were not any changes except stored procedure definition being fully loaded.


#
### Type of change:
- [1] Bug fix
#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`


Bug fix
- [1] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.


